### PR TITLE
Add New Methods to help with system orchestration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: focal
+dist: xenial
 
 arch:
 - amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: focal
+
 arch:
 - amd64
 - ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: bionic
+dist: xenial
 
 arch:
 - amd64
@@ -8,7 +8,7 @@ arch:
 
 php:
 - 7.4
-- 8.0.23
+- 8.0
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
   email:
   - team@appwrite.io
 
-before_script: composer install --ignore-platform-reqs
+before_script: apt-get install libargon2-0 && composer install --ignore-platform-reqs
 
 script:
 - vendor/bin/phpunit --configuration phpunit.xml --testsuite General

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
   email:
   - team@appwrite.io
 
-before_script: sudo apt-get install libargon2-0 && composer install --ignore-platform-reqs
+before_script: composer install --ignore-platform-reqs
 
 script:
 - vendor/bin/phpunit --configuration phpunit.xml --testsuite General

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ arch:
 
 php:
 - 7.4
-- 8.0
+- 8.0.23
 - nightly
 
 notifications:
   email:
   - team@appwrite.io
 
-before_script: apt-get install libargon2-0 && composer install --ignore-platform-reqs
+before_script: sudo apt-get install libargon2-0 && composer install --ignore-platform-reqs
 
 script:
 - vendor/bin/phpunit --configuration phpunit.xml --testsuite General

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: xenial
+dist: bionic
 
 arch:
 - amd64
@@ -9,7 +9,6 @@ arch:
 php:
 - 7.4
 - 8.0.23
-- nightly
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
-dist: xenial
+dist: focal
 
 arch:
 - amd64
-- ppc64le
 - arm64
 
 php:
@@ -22,5 +21,4 @@ script:
 - vendor/bin/phpunit --configuration phpunit.xml --testsuite General
 - vendor/bin/psalm --show-info=true
 - if [ "$TRAVIS_CPU_ARCH" = "amd64" ]; then vendor/bin/phpunit --configuration phpunit.xml --testsuite X86; fi
-- if [ "$TRAVIS_CPU_ARCH" = "ppc64le" ]; then vendor/bin/phpunit --configuration phpunit.xml --testsuite PPC; fi
 - if [ "$TRAVIS_CPU_ARCH" = "arm64" ]; then vendor/bin/phpunit --configuration phpunit.xml --testsuite ARM; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM composer:2.0 as composer
+
+ARG TESTING=false
+ENV TESTING=$TESTING
+
+WORKDIR /usr/local/src/
+
+COPY composer.lock /usr/local/src/
+COPY composer.json /usr/local/src/
+
+RUN composer update --ignore-platform-reqs --optimize-autoloader \
+    --no-plugins --no-scripts --prefer-dist
+    
+FROM php:8.0-cli-alpine as compile
+    
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN \
+  apk update \
+  && apk add --no-cache make automake autoconf gcc g++ git brotli-dev \
+  && docker-php-ext-install opcache \
+  && rm -rf /var/cache/apk/*
+
+FROM compile as final
+
+LABEL maintainer="team@appwrite.io"
+
+WORKDIR /usr/src/code
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+RUN echo "opcache.enable_cli=1" >> $PHP_INI_DIR/php.ini
+
+COPY --from=composer /usr/local/src/vendor /usr/src/code/vendor
+
+# Add Source Code
+COPY . /usr/src/code
+
+CMD [ "tail", "-f", "/dev/null" ]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ echo System::isX86(); // bool
 
 Utopia Framework requires PHP 7.4 or later. We recommend using the latest PHP version whenever possible.
 
+## Supported Methods
+|         | getCPUCores | getCPUUtilisation | getMemoryTotal | getMemoryFree | getDiskTotal | getDiskFree | getIOUsage | getNetworkUsage |
+|---------|-------------|-------------------|----------------|---------------|--------------|-------------|------------|-----------------|
+| Windows | ✅           |                   |                |               | ✅            | ✅           |            |                 |
+| MacOS   | ✅           |                   | ✅              | ✅             | ✅            | ✅           |            |                 |
+| Linux   | ✅           | ✅                 | ✅              | ✅             | ✅            | ✅           | ✅          | ✅               |
+
 ## Authors
 
 **Eldad Fux**

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",
-        "vimeo/psalm": "4.0.1"
+        "vimeo/psalm": "4.0.1",
+        "squizlabs/php_codesniffer": "^3.6"
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  main-test:
+    build:
+      context: .
+    mem_limit: 512m
+    mem_reservation: 128M
+    cpus: 0.5
+    command: tail -f /dev/null
+    volumes:
+      - ./:/usr/src/code

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -224,13 +224,13 @@ class System
                 $cpuNumber = 'total';
             }
 
-            $data[$cpuNumber]['user'] = $cpu[1];
-            $data[$cpuNumber]['nice'] = $cpu[2];
-            $data[$cpuNumber]['system'] = $cpu[3];
-            $data[$cpuNumber]['idle'] = $cpu[4];
-            $data[$cpuNumber]['iowait'] = $cpu[5];
-            $data[$cpuNumber]['irq'] = $cpu[6];
-            $data[$cpuNumber]['softirq'] = $cpu[7];
+            $data[$cpuNumber]['user'] = $cpu[1] ?? 0;
+            $data[$cpuNumber]['nice'] = $cpu[2] ?? 0;
+            $data[$cpuNumber]['system'] = $cpu[3] ?? 0;
+            $data[$cpuNumber]['idle'] = $cpu[4] ?? 0;
+            $data[$cpuNumber]['iowait'] = $cpu[5] ?? 0;
+            $data[$cpuNumber]['irq'] = $cpu[6] ?? 0;
+            $data[$cpuNumber]['softirq'] = $cpu[7] ?? 0;
 
             // These might not exist on older kernels.
             $data[$cpuNumber]['steal'] = $cpu[8] ?? 0;
@@ -252,15 +252,15 @@ class System
             ];
 
             foreach ($data as $cpu) {
-                $data['total']['user'] += $cpu['user'];
-                $data['total']['nice'] += $cpu['nice'];
-                $data['total']['system'] += $cpu['system'];
-                $data['total']['idle'] += $cpu['idle'];
-                $data['total']['iowait'] += $cpu['iowait'];
-                $data['total']['irq'] += $cpu['irq'];
-                $data['total']['softirq'] += $cpu['softirq'];
-                $data['total']['steal'] += $cpu['steal'];
-                $data['total']['guest'] += $cpu['guest'];
+                $data['total']['user'] += intval($cpu['user']);
+                $data['total']['nice'] += intval($cpu['nice'] ?? 0);
+                $data['total']['system'] += intval($cpu['system'] ?? 0);
+                $data['total']['idle'] += intval($cpu['idle'] ?? 0);
+                $data['total']['iowait'] += intval($cpu['iowait'] ?? 0);
+                $data['total']['irq'] += intval($cpu['irq'] ?? 0);
+                $data['total']['softirq'] += intval($cpu['softirq'] ?? 0);
+                $data['total']['steal'] += intval($cpu['steal'] ?? 0);
+                $data['total']['guest'] += intval($cpu['guest'] ?? 0);
             }
         }
 
@@ -325,22 +325,22 @@ class System
     static public function getMemoryTotal(): int
     {
         switch (self::getOS()) {
-            case 'Linux':
-                $meminfo = file_get_contents('/proc/meminfo');
-                preg_match('/MemTotal:\s+(\d+)/', $meminfo, $matches);
+        case 'Linux':
+            $meminfo = file_get_contents('/proc/meminfo');
+            preg_match('/MemTotal:\s+(\d+)/', $meminfo, $matches);
 
-                if (isset($matches[1])) {
-                    return intval(intval($matches[1]) / 1024);
-                } else {
-                    throw new Exception('Could not find MemTotal in /proc/meminfo.');
-                }
-                break;
-            case 'Darwin':
-                return intval((intval(shell_exec('sysctl -n hw.memsize'))) / 1024 / 1024);
-                break;
-            default:
-                throw new Exception(self::getOS() . " not supported.");
+            if (isset($matches[1])) {
+                return intval(intval($matches[1]) / 1024);
+            } else {
+                throw new Exception('Could not find MemTotal in /proc/meminfo.');
             }
+            break;
+        case 'Darwin':
+            return intval((intval(shell_exec('sysctl -n hw.memsize'))) / 1024 / 1024);
+            break;
+        default:
+            throw new Exception(self::getOS() . " not supported.");
+        }
     }
 
     /**
@@ -457,7 +457,7 @@ class System
         // Remove invalid disks
         $diskStat = array_filter($diskStat, function ($disk) {
             foreach (self::InvalidDisks as $filter) {
-                if (!$disk[2]) {
+                if (!isset($disk[2])) {
                     return false;
                 }
                 if (str_contains($disk[2], $filter)) {
@@ -470,7 +470,7 @@ class System
 
         $diskStat2 = array_filter($diskStat2, function ($disk) {
             foreach (self::InvalidDisks as $filter) {
-                if (!$disk[2]) {
+                if (!isset($disk[2])) {
                     return false;
                 }
 

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -25,7 +25,7 @@ class System
      * Loop - https://man7.org/linux/man-pages/man4/loop.4.html
      * Ram - https://man7.org/linux/man-pages/man4/ram.4.html
      */
-    private const InvalidDisks = [
+    private const INVALIDDISKS = [
         'loop',
         'ram',
     ];
@@ -45,7 +45,7 @@ class System
      * vboxnet - Virtual Machine Networking Interface, https://www.virtualbox.org/manual/ch06.html
      * bonding_masters - https://www.kernel.org/doc/Documentation/networking/bonding.txt
      */
-    private const InvalidNetInterfaces = [
+    private const INVALIDNETINTERFACES = [
         'veth',
         'docker',
         'lo',
@@ -57,6 +57,7 @@ class System
 
     /**
      * Returns the system's OS.
+     * 
      * @return string
      */
     static public function getOS(): string
@@ -85,19 +86,19 @@ class System
     {
         $arch = self::getArch();
         switch (1) {
-            case preg_match(self::RegExX86, $arch):
-                return System::X86;
-                break;
-            case preg_match(self::RegExPPC, $arch):
-                return System::PPC;
-                break;
-            case preg_match(self::RegExARM, $arch):
-                return System::ARM;
-                break;
+        case preg_match(self::RegExX86, $arch):
+            return System::X86;
+            break;
+        case preg_match(self::RegExPPC, $arch):
+            return System::PPC;
+            break;
+        case preg_match(self::RegExARM, $arch):
+            return System::ARM;
+            break;
 
-            default:
-                throw new Exception("'{$arch}' enum not found.");
-                break;
+        default:
+            throw new Exception("'{$arch}' enum not found.");
+            break;
         }
     }
 
@@ -154,19 +155,19 @@ class System
     static public function isArch(string $arch): bool
     {
         switch ($arch) {
-            case self::X86:
-                return self::isX86();
-                break;
-            case self::PPC:
-                return self::isPPC();
-                break;
-            case self::ARM:
-                return self::isArm();
-                break;
+        case self::X86:
+            return self::isX86();
+            break;
+        case self::PPC:
+            return self::isPPC();
+            break;
+        case self::ARM:
+            return self::isArm();
+            break;
 
-            default:
-                throw new Exception("'{$arch}' not found.");
-                break;
+        default:
+            throw new Exception("'{$arch}' not found.");
+            break;
         }
     }
 
@@ -353,18 +354,18 @@ class System
     static public function getMemoryFree(): int
     {
         switch (self::getOS()) {
-            case 'Linux':
-                $meminfo = file_get_contents('/proc/meminfo');
-                preg_match('/MemFree:\s+(\d+)/', $meminfo, $matches);
-                if (isset($matches[1])) {
-                    return intval(intval($matches[1]) / 1024);
-                } else {
-                    throw new Exception('Could not find MemFree in /proc/meminfo.');
-                }
-            case 'Darwin':
-                return intval(intval(shell_exec('sysctl -n vm.page_free_count')) / 1024 / 1024);
-            default:
-                throw new Exception(self::getOS() . " not supported.");
+        case 'Linux':
+            $meminfo = file_get_contents('/proc/meminfo');
+            preg_match('/MemFree:\s+(\d+)/', $meminfo, $matches);
+            if (isset($matches[1])) {
+                return intval(intval($matches[1]) / 1024);
+            } else {
+                throw new Exception('Could not find MemFree in /proc/meminfo.');
+            }
+        case 'Darwin':
+            return intval(intval(shell_exec('sysctl -n vm.page_free_count')) / 1024 / 1024);
+        default:
+            throw new Exception(self::getOS() . " not supported.");
         }
     }
 
@@ -456,7 +457,7 @@ class System
 
         // Remove invalid disks
         $diskStat = array_filter($diskStat, function ($disk) {
-            foreach (self::InvalidDisks as $filter) {
+            foreach (self::INVALIDDISKS as $filter) {
                 if (!isset($disk[2])) {
                     return false;
                 }
@@ -469,7 +470,7 @@ class System
         });
 
         $diskStat2 = array_filter($diskStat2, function ($disk) {
-            foreach (self::InvalidDisks as $filter) {
+            foreach (self::INVALIDDISKS as $filter) {
                 if (!isset($disk[2])) {
                     return false;
                 }
@@ -497,11 +498,13 @@ class System
     }
 
     /**
-     * Returns an array of all the available network interfaces on the system containing
-     * the current download and upload usage in Megabytes.
-     * There is also a ['total'] key that contains the total amount of download and upload
+     * Returns an array of all the available network interfaces on the system 
+     * containing the current download and upload usage in Megabytes.
+     * There is also a ['total'] key that contains the total amount of download
+     * and upload
      * 
-     * @param int $duration
+     * @param int $duration The buffer duration to fetch the data points
+     * 
      * @return array
      * 
      * @throws Exception
@@ -513,7 +516,7 @@ class System
 
         // Remove all unwanted interfaces
         $interfaces = array_filter($interfaces, function ($interface) {
-            foreach (self::InvalidNetInterfaces as $filter) {
+            foreach (self::INVALIDNETINTERFACES as $filter) {
                 if (str_contains($interface, $filter)) {
                     return false;
                 }

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -171,9 +171,9 @@ class System
                 preg_match_all('/^processor/m', $cpuinfo, $matches);
                 return count($matches[0]);
             case 'Darwin':
-                return shell_exec('sysctl -n hw.ncpu');
+                return intval(shell_exec('sysctl -n hw.ncpu'));
             case 'Windows':
-                return shell_exec('wmic cpu get NumberOfCores');
+                return intval(shell_exec('wmic cpu get NumberOfCores'));
             default:
                 throw new Exception(self::getOS() . " not supported.");
         }
@@ -389,7 +389,7 @@ class System
 
         // Remove excess spaces
         $diskstats = array_map(function ($data) {
-            return preg_replace('/\s+/', ' ', trim($data));
+            return preg_replace('/\t+/', ' ', trim($data));
         }, $diskstats);
 
         // Remove empty lines

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -39,7 +39,8 @@ class System
         'lo',
         'tun',
         'vboxnet',
-        '.'
+        '.',
+        'bonding_masters'
     ];
 
     /**

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -15,6 +15,33 @@ class System
     private const RegExPPC = '/(ppc*)/';
 
     /**
+     * A list of Linux Disks that are not considered valid
+     * These are usually virtual drives or other non-physical devices such as loopback or ram.
+     * 
+     * This list is ran through a contains, meaning for example if 'loop' was in the list,
+     * A 'loop0' interface would be considered invalid and not computed.
+     */
+    private const InvalidDisks = [
+        'loop',
+        'ram',
+    ];
+
+    /**
+     * A list of Linux Network Interfaces that are not considered valid
+     * These are usually virtual interfaces created by tools such as Docker or VirtualBox
+     * 
+     * This list is ran through a contains, meaning for example if 'vboxnet' was in the list,
+     * A 'vboxnet0' interface would be considered invalid and not computed.
+     */
+    private const InvalidNetInterfaces = [
+        'veth',
+        'docker',
+        'lo',
+        'tun',
+        'vboxnet'
+    ];
+
+    /**
      * Returns the system's OS.
      * @return string
      */
@@ -127,5 +154,352 @@ class System
                 throw new Exception("'{$arch}' not found.");
                 break;
         }
+    }
+
+    /**
+     * Gets the system's total amount of CPU cores.
+     * 
+     * @return int
+     * 
+     * @throws Exception
+     */
+    static public function getCPUCores(): int
+    {
+        switch (self::getOS()) {
+            case 'Linux':
+                $cpuinfo = file_get_contents('/proc/cpuinfo');
+                preg_match_all('/^processor/m', $cpuinfo, $matches);
+                return count($matches[0]);
+            case 'Darwin':
+                return shell_exec('sysctl -n hw.ncpu');
+            case 'Windows':
+                return shell_exec('wmic cpu get NumberOfCores');
+            default:
+                throw new Exception(self::getOS() . " not supported.");
+        }
+    }
+
+    /**
+     * Helper function to read a Linux System's /proc/stat data and convert it into an array.
+     * 
+     * @return array
+     */
+    static private function getProcStatData(): array
+    {
+        $data = [];
+
+        $totalCPUExists = false;
+
+        $cpustats = file_get_contents('/proc/stat');
+
+        $cpus = explode("\n", $cpustats);
+
+        // Remove non-CPU lines
+        $cpus = array_filter($cpus, function ($cpu) {
+            return preg_match('/^cpu[0-999]/', $cpu);
+        });
+
+        foreach ($cpus as $cpu) {
+            $cpu = explode(' ', $cpu);
+
+            // get CPU number
+            $cpuNumber = substr($cpu[0], 3);
+
+            if ($cpu[0] === 'cpu') {
+                $totalCPUExists = true;
+                $cpuNumber = 'total';
+            }
+
+            $data[$cpuNumber]['user'] = $cpu[1];
+            $data[$cpuNumber]['nice'] = $cpu[2];
+            $data[$cpuNumber]['system'] = $cpu[3];
+            $data[$cpuNumber]['idle'] = $cpu[4];
+            $data[$cpuNumber]['iowait'] = $cpu[5];
+            $data[$cpuNumber]['irq'] = $cpu[6];
+            $data[$cpuNumber]['softirq'] = $cpu[7];
+
+            // These might not exist on older kernels.
+            $data[$cpuNumber]['steal'] = isset($cpu[8]) ? $cpu[8] : 0;
+            $data[$cpuNumber]['guest'] = isset($cpu[9]) ? $cpu[9] : 0;
+        }
+
+        if (!$totalCPUExists) {
+            // Combine all values
+            $data['total'] = [
+                'user' => 0,
+                'nice' => 0,
+                'system' => 0,
+                'idle' => 0,
+                'iowait' => 0,
+                'irq' => 0,
+                'softirq' => 0,
+                'steal' => 0,
+                'guest' => 0
+            ];
+
+            foreach ($data as $cpu) {
+                $data['total']['user'] += $cpu['user'];
+                $data['total']['nice'] += $cpu['nice'];
+                $data['total']['system'] += $cpu['system'];
+                $data['total']['idle'] += $cpu['idle'];
+                $data['total']['iowait'] += $cpu['iowait'];
+                $data['total']['irq'] += $cpu['irq'];
+                $data['total']['softirq'] += $cpu['softirq'];
+                $data['total']['steal'] += $cpu['steal'];
+                $data['total']['guest'] += $cpu['guest'];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Gets the current usage of a core as a percentage. Passing 0 will return the usage of all cores combined.
+     * 
+     * @param int $core
+     * 
+     * @return int
+     * 
+     * @throws Exception
+     */
+    static public function getCPUUtilisation(int $id = 0): int
+    {
+        switch (self::getOS()) {
+            case 'Linux':
+                $cpuNow = self::getProcStatData();
+                $i = 0;
+
+                $data = [];
+
+                foreach ($cpuNow as $cpu) {
+                    // Check if this is the total CPU
+                    $cpuTotal = $cpu['user'] + $cpu['nice'] + $cpu['system'] + $cpu['idle'] + $cpu['iowait'] + $cpu['irq'] + $cpu['softirq'] + $cpu['steal'];
+
+                    $cpuIdle = $cpu['idle'];
+
+                    $idleDelta = $cpuIdle - (isset($lastData[$i]) ? $lastData[$i]['idle'] : 0);
+
+                    $totalDelta = $cpuTotal - (isset($lastData[$i]) ? $lastData[$i]['total'] : 0);
+
+                    $lastData[$i]['total'] = $cpuTotal;
+                    $lastData[$i]['idle'] = $cpuIdle;
+
+                    $result = (1.0 - ($idleDelta / $totalDelta)) * 100;
+
+                    $data[$i] = $result;
+
+                    $i++;
+                }
+
+                if ($id === 0) {
+                    return array_sum($data);
+                } else {
+                    return $data[$id];
+                }
+        }
+    }
+
+    /**
+     * Returns the total amount of RAM available on the system as Megabytes.
+     * 
+     * @return int
+     * 
+     * @throws Exception
+     */
+    static public function getMemoryTotal(): int
+    {
+        switch (self::getOS()) {
+            case 'Linux':
+                $meminfo = file_get_contents('/proc/meminfo');
+                preg_match('/MemTotal:\s+(\d+)/', $meminfo, $matches);
+                return intval(intval($matches[1]) / 1024);
+                break;
+            case 'Darwin':
+                return intval((intval(shell_exec('sysctl -n hw.memsize'))) / 1024 / 1024);
+        }
+    }
+
+    /**
+     * Returns the total amount of Free RAM available on the system as Megabytes.
+     * 
+     * @return int
+     * 
+     * @throws Exception
+     */
+    static public function getMemoryFree(): int
+    {
+        switch (self::getOS()) {
+            case 'Linux':
+                $meminfo = file_get_contents('/proc/meminfo');
+                preg_match('/MemFree:\s+(\d+)/', $meminfo, $matches);
+                return ($matches[1] / 1024);
+            case 'Darwin':
+                return intval(intval(shell_exec('sysctl -n vm.page_free_count')) / 1024 / 1024);
+        }
+    }
+
+    /**
+     * Returns the total amount of Disk space on the system as Megabytes.
+     * 
+     * @return int
+     * 
+     * @throws Exception
+     */
+    static public function getDiskTotal(): int
+    {
+        $totalSpace = disk_total_space(__DIR__);
+
+        if ($totalSpace === false) {
+            throw new Exception('Unable to get disk space');
+        }
+
+        return intval($totalSpace / 1024 / 1024);
+    }
+
+    /**
+     * Returns the total amount of Disk space free on the system as Megabytes.
+     * 
+     * @return int
+     * 
+     * @throws Exception
+     */
+    static public function getDiskFree(): int
+    {
+        $totalSpace = disk_free_space(__DIR__);
+
+        if ($totalSpace === false) {
+            throw new Exception('Unable to get free disk space');
+        }
+
+        return intval($totalSpace / 1024 / 1024);
+    }
+
+    /**
+     * Helper function to read a Linux System's /proc/diskstats data and convert it into an array.
+     * 
+     * @return array
+     */
+    static private function getDiskStats()
+    {
+        // Read /proc/diskstats
+        $diskstats = file_get_contents('/proc/diskstats');
+
+        // Split the data
+        $diskstats = explode("\n", $diskstats);
+
+        // Remove excess spaces
+        $diskstats = array_map(function ($data) {
+            return preg_replace('/\s+/', ' ', trim($data));
+        }, $diskstats);
+
+        // Remove empty lines
+        $diskstats = array_filter($diskstats, function ($data) {
+            return !empty($data);
+        });
+
+        $data = [];
+        foreach ($diskstats as $disk) {
+            // Breakdown the data
+            $disk = explode(' ', $disk);
+
+            $data[$disk[2]] = $disk;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Returns an array of all the available storage devices on the system containing
+     * the current read and write usage in Megabytes.
+     * There is also a ['total'] key that contains the total amount of read and write usage.
+     * 
+     * @return array
+     * 
+     * @throws Exception
+     */
+    static public function getIOUsage(): array
+    {
+        $diskStat = self::getDiskStats();
+        sleep(1);
+        $diskStat2 = self::getDiskStats();
+
+        // Remove invalid disks
+        $diskStat = array_filter($diskStat, function ($disk) {
+            foreach (self::InvalidDisks as $filter) {
+                if (str_contains($disk[2], $filter)) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        $diskStat2 = array_filter($diskStat2, function ($disk) {
+            foreach (self::InvalidDisks as $filter) {
+                if (str_contains($disk[2], $filter)) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        $stats = [];
+
+        // Compute Delta
+        foreach ($diskStat as $key => $disk) {
+            $stats[$key]['read'] = (((intval($diskStat2[$key][5]) - intval($disk[5])) * 512) / 1048576);
+            $stats[$key]['write'] = (((intval($diskStat2[$key][9]) - intval($disk[9])) * 512) / 1048576);
+        }
+
+        $stats['total']['read'] = array_sum(array_column($stats, 'read'));
+        $stats['total']['write'] = array_sum(array_column($stats, 'write'));
+
+        return $stats;
+    }
+
+    /**
+     * Returns an array of all the available network interfaces on the system containing
+     * the current download and upload usage in Megabytes.
+     * There is also a ['total'] key that contains the total amount of download and upload
+     * 
+     * @return array
+     * 
+     * @throws Exception
+     */
+    static public function getNetworkUsage(): array
+    {
+        // Create a list of interfaces
+        $interfaces = scandir('/sys/class/net', SCANDIR_SORT_NONE);
+
+        // Remove all unwanted interfaces
+        $interfaces = array_filter($interfaces, function ($interface) {
+            foreach (self::InvalidDisks as $filter) {
+                if (str_contains($interface, $filter)) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        // Get the total IO Usage
+        $IOUsage = [];
+
+        foreach ($interfaces as $interface) {
+            $tx1 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/tx_bytes'));
+            $rx1 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/rx_bytes'));
+            sleep(1);
+            $tx2 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/tx_bytes'));
+            $rx2 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/rx_bytes'));
+
+            $IOUsage[$interface]['download'] = round(($rx2 - $rx1) / 1048576, 2);
+            $IOUsage[$interface]['upload'] = round(($tx2 - $tx1) / 1048576, 2);
+        }
+
+        $IOUsage['total']['download'] = array_sum(array_column($IOUsage, 'download'));
+        $IOUsage['total']['upload'] = array_sum(array_column($IOUsage, 'upload'));
+
+        return $IOUsage;
     }
 }

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -422,14 +422,15 @@ class System
      * the current read and write usage in Megabytes.
      * There is also a ['total'] key that contains the total amount of read and write usage.
      * 
+     * @param int $duration
      * @return array
      * 
      * @throws Exception
      */
-    static public function getIOUsage(): array
+    static public function getIOUsage($duration = 1): array
     {
         $diskStat = self::getDiskStats();
-        sleep(1);
+        sleep($duration);
         $diskStat2 = self::getDiskStats();
 
         // Remove invalid disks
@@ -472,11 +473,12 @@ class System
      * the current download and upload usage in Megabytes.
      * There is also a ['total'] key that contains the total amount of download and upload
      * 
+     * @param int $duration
      * @return array
      * 
      * @throws Exception
      */
-    static public function getNetworkUsage(): array
+    static public function getNetworkUsage($duration = 1): array
     {
         // Create a list of interfaces
         $interfaces = scandir('/sys/class/net', SCANDIR_SORT_NONE);
@@ -498,7 +500,7 @@ class System
         foreach ($interfaces as $interface) {
             $tx1 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/tx_bytes'));
             $rx1 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/rx_bytes'));
-            sleep(1);
+            sleep($duration);
             $tx2 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/tx_bytes'));
             $rx2 = intval(file_get_contents('/sys/class/net/' . $interface . '/statistics/rx_bytes'));
 

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -38,7 +38,8 @@ class System
         'docker',
         'lo',
         'tun',
-        'vboxnet'
+        'vboxnet',
+        '.'
     ];
 
     /**
@@ -292,10 +293,12 @@ class System
                 }
 
                 if ($id === 0) {
-                    return array_sum($data);
+                    return intval(array_sum($data));
                 } else {
                     return $data[$id];
                 }
+            default:
+                throw new Exception(self::getOS() . " not supported.");
         }
     }
 
@@ -316,7 +319,10 @@ class System
                 break;
             case 'Darwin':
                 return intval((intval(shell_exec('sysctl -n hw.memsize'))) / 1024 / 1024);
-        }
+                break;
+            default:
+                throw new Exception(self::getOS() . " not supported.");
+            }
     }
 
     /**
@@ -332,9 +338,11 @@ class System
             case 'Linux':
                 $meminfo = file_get_contents('/proc/meminfo');
                 preg_match('/MemFree:\s+(\d+)/', $meminfo, $matches);
-                return ($matches[1] / 1024);
+                return intval($matches[1] / 1024);
             case 'Darwin':
                 return intval(intval(shell_exec('sysctl -n vm.page_free_count')) / 1024 / 1024);
+            default:
+                throw new Exception(self::getOS() . " not supported.");
         }
     }
 
@@ -474,7 +482,7 @@ class System
 
         // Remove all unwanted interfaces
         $interfaces = array_filter($interfaces, function ($interface) {
-            foreach (self::InvalidDisks as $filter) {
+            foreach (self::InvalidNetInterfaces as $filter) {
                 if (str_contains($interface, $filter)) {
                     return false;
                 }

--- a/tests/System/SystemTest.php
+++ b/tests/System/SystemTest.php
@@ -41,4 +41,69 @@ class SystemTest extends TestCase
         $this->expectException("Exception");
         System::isArch("throw");
     }
+
+    public function testGetCPUCores()
+    {
+        $this->assertIsInt(System::getCPUCores());
+    }
+
+    public function testGetDiskTotal()
+    {
+        $this->assertIsInt(System::getDiskTotal());
+    }
+
+    public function testGetDiskFree()
+    {
+        $this->assertIsInt(System::getDiskFree());
+    }
+    
+    // Methods only implemented for Linux
+    public function testGetCPUUtilisation()
+    {
+        if (System::getOS() === 'Linux') {
+            $this->assertIsInt(System::getCPUUtilisation());
+        } else {
+            $this->expectException("Exception");
+            System::getCPUUtilisation();
+        }
+    }
+
+    public function testGetMemoryTotal()
+    {
+        if (System::getOS() === 'Linux') {
+            $this->assertIsInt(System::getMemoryTotal());
+        } else {
+            $this->expectException("Exception");
+            System::getMemoryTotal();
+        }
+    }
+
+    public function testGetMemoryFree()
+    {
+        if (System::getOS() === 'Linux') {
+            $this->assertIsInt(System::getMemoryFree());
+        } else {
+            $this->expectException("Exception");
+            System::getMemoryFree();
+        }
+    }
+
+    public function testGetIOUsage()
+    {
+        if (System::getOS() === 'Linux') {
+            $this->assertIsArray(System::getIOUsage());
+        } else {
+            $this->expectException("Exception");
+            System::getIOUsage();
+        }
+    }
+
+    public function testGetNetworkUsage() {
+        if (System::getOS() === 'Linux') {
+            $this->assertIsArray(System::getNetworkUsage());
+        } else {
+            $this->expectException("Exception");
+            System::getNetworkUsage();
+        }
+    }
 }


### PR DESCRIPTION
+ Added getCPUCores()
+ Added UNIX Helper functions
+ Added getCPUUtilisation
+ Added getMemoryTotal()
+ Added getMemoryFree()
+ Added getDiskTotal()
+ Added getDiskFree()
+ Added getDiskStats()
+ Added getIOUsage()
+ Added getNetworkUsage()

Most of these methods are currently Linux only and are currently being iterated on to improve stability.