### PR TITLE
Feat: getCPUUsage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ echo System::isX86(); // bool
 Utopia Framework requires PHP 7.4 or later. We recommend using the latest PHP version whenever possible.
 
 ## Supported Methods
-|         | getCPUCores | getCPUUtilisation | getMemoryTotal | getMemoryFree | getDiskTotal | getDiskFree | getIOUsage | getNetworkUsage |
+|         | getCPUCores | getCPUUsage | getMemoryTotal | getMemoryFree | getDiskTotal | getDiskFree | getIOUsage | getNetworkUsage |
 |---------|-------------|-------------------|----------------|---------------|--------------|-------------|------------|-----------------|
 | Windows | ✅           |                   |                |               | ✅            | ✅           |            |                 |
 | MacOS   | ✅           |                   | ✅              | ✅             | ✅            | ✅           |            |                 |

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -320,6 +320,42 @@ class System
     }
 
     /**
+     * Get percentage CPU usage (between 0 and 100)
+     *
+     * @param  int $duration
+     * @return float
+     *
+     * @throws Exception
+     */
+    public static function getCPUUsage(int $duration = 1): float
+    {
+        switch (self::getOS()) {
+            case 'Linux':
+                $startCpu = self::getProcStatData()['total'];
+                \sleep($duration);
+                $endCpu = self::getProcStatData()['total'];
+
+                $prevIdle = $startCpu['idle'] + $startCpu['iowait'];
+                $idle = $endCpu['idle'] + $endCpu['iowait'];
+
+                $prevNonIdle = $startCpu['user'] + $startCpu['nice'] + $startCpu['system'] + $startCpu['irq'] + $startCpu['softirq'] + $startCpu['steal'];
+                $nonIdle = $endCpu['user'] + $endCpu['nice'] + $endCpu['system'] + $endCpu['irq'] + $endCpu['softirq'] + $endCpu['steal'];
+
+                $prevTotal = $prevIdle + $prevNonIdle;
+                $total = $idle + $nonIdle;
+
+                $totalDiff = $total - $prevTotal;
+                $idleDiff = $idle - $prevIdle;
+
+                $percentage = ($totalDiff - $idleDiff) / $totalDiff;
+
+                return $percentage * 100;
+            default:
+                throw new Exception(self::getOS().' not supported.');
+        }
+    }
+
+    /**
      * Returns the total amount of RAM available on the system as Megabytes.
      *
      * @return int

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -273,53 +273,6 @@ class System
     }
 
     /**
-     * Gets the current usage of a core as a percentage. Passing 0 will return the usage of all cores combined.
-     *
-     * @param  int  $core
-     * @return int
-     *
-     * @throws Exception
-     */
-    public static function getCPUUtilisation(int $id = 0): int
-    {
-        switch (self::getOS()) {
-            case 'Linux':
-                $cpuNow = self::getProcStatData();
-                $i = 0;
-
-                $data = [];
-
-                foreach ($cpuNow as $cpu) {
-                    // Check if this is the total CPU
-                    $cpuTotal = $cpu['user'] + $cpu['nice'] + $cpu['system'] + $cpu['idle'] + $cpu['iowait'] + $cpu['irq'] + $cpu['softirq'] + $cpu['steal'];
-
-                    $cpuIdle = $cpu['idle'];
-
-                    $idleDelta = $cpuIdle - (isset($lastData[$i]) ? $lastData[$i]['idle'] : 0);
-
-                    $totalDelta = $cpuTotal - (isset($lastData[$i]) ? $lastData[$i]['total'] : 0);
-
-                    $lastData[$i]['total'] = $cpuTotal;
-                    $lastData[$i]['idle'] = $cpuIdle;
-
-                    $result = (1.0 - ($idleDelta / $totalDelta)) * 100;
-
-                    $data[$i] = $result;
-
-                    $i++;
-                }
-
-                if ($id === 0) {
-                    return intval(array_sum($data));
-                } else {
-                    return $data[$id];
-                }
-            default:
-                throw new Exception(self::getOS().' not supported.');
-        }
-    }
-
-    /**
      * Get percentage CPU usage (between 0 and 100)
      * Reference for formula: https://stackoverflow.com/a/23376195/17300412
      *

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -321,6 +321,7 @@ class System
 
     /**
      * Get percentage CPU usage (between 0 and 100)
+     * Refference for formula: https://stackoverflow.com/a/23376195/17300412
      *
      * @param  int  $duration
      * @return float

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -322,7 +322,7 @@ class System
     /**
      * Get percentage CPU usage (between 0 and 100)
      *
-     * @param  int $duration
+     * @param  int  $duration
      * @return float
      *
      * @throws Exception

--- a/src/System/System.php
+++ b/src/System/System.php
@@ -321,7 +321,7 @@ class System
 
     /**
      * Get percentage CPU usage (between 0 and 100)
-     * Refference for formula: https://stackoverflow.com/a/23376195/17300412
+     * Reference for formula: https://stackoverflow.com/a/23376195/17300412
      *
      * @param  int  $duration
      * @return float

--- a/tests/System/SystemTest.php
+++ b/tests/System/SystemTest.php
@@ -59,24 +59,13 @@ class SystemTest extends TestCase
     }
 
     // Methods only implemented for Linux
-    public function testGetCPUUtilisation()
-    {
-        if (System::getOS() === 'Linux') {
-            $this->assertIsInt(System::getCPUUtilisation());
-        } else {
-            $this->expectException('Exception');
-            System::getCPUUtilisation();
-        }
-    }
-
-    // Methods only implemented for Linux
     public function testGetCPUUsage()
     {
         if (System::getOS() === 'Linux') {
             $this->assertIsNumeric(System::getCPUUsage(5));
         } else {
             $this->expectException('Exception');
-            System::getCPUUtilisation();
+            System::getCPUUsage(5);
         }
     }
 

--- a/tests/System/SystemTest.php
+++ b/tests/System/SystemTest.php
@@ -69,6 +69,17 @@ class SystemTest extends TestCase
         }
     }
 
+    // Methods only implemented for Linux
+    public function testGetCPUUsage()
+    {
+        if (System::getOS() === 'Linux') {
+            $this->assertIsNumeric(System::getCPUUsage(5));
+        } else {
+            $this->expectException('Exception');
+            System::getCPUUtilisation();
+        }
+    }
+
     public function testGetMemoryTotal()
     {
         if (System::getOS() === 'Linux') {


### PR DESCRIPTION
Method useful for simply getting the percentage of CPU usage between 0 and 100. This is used in the Appwrite functions proxy as part of CPUBasedAdapter proxy.

- [x] Tests implemented