### PR TITLE
Fix macOS check for arm64

### DIFF
--- a/src/System/System.php
+++ b/src/System/System.php
@@ -18,7 +18,7 @@ class System
 
     private const RegExX86 = '/(x86*|i386|i686)/';
 
-    private const RegexARM64 = '/(aarch64)/';
+    private const RegexARM64 = '/(aarch64|arm64)/';
 
     private const RegexARMV7 = '/(armv7)/';
 


### PR DESCRIPTION
Currently an exception is thrown on macOS because `uname` returns `arm64` instead of `aarch64`