### PR TITLE
feat: add conditional return type to getEnv

### DIFF
--- a/src/System/System.php
+++ b/src/System/System.php
@@ -530,9 +530,9 @@ class System
     }
 
     /**
-     * Checks if the system is running on an ARM64 architecture.
-     *
-     * @return string|null
+     * @template TDefault of string|null
+     * @param TDefault $default
+     * @return ($default is null ? string|null : string)
      */
     public static function getEnv(string $name, ?string $default = null): ?string
     {


### PR DESCRIPTION
## Summary

- Adds PHPStan conditional return type annotation to `getEnv`
- When `$default` is `null` (or omitted), return type is `string|null`
- When a non-null `string` is passed, return type narrows to `string`
- Eliminates the need for `?? fallback` at call sites where a non-null default is provided

## Test plan

- [x] PHPStan passes at `--level=max`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved type annotations for enhanced code reliability and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->